### PR TITLE
Allow `old` to be `undefined` for a change record

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rbxts/matter",
-  "version": "0.1.2-ts.5",
+  "version": "0.1.2-ts.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rbxts/matter",
-      "version": "0.1.2-ts.4",
+      "version": "0.1.2-ts.6",
       "license": "ISC",
       "dependencies": {
         "@rbxts/llama": "^1.1.0-ts2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rbxts/matter",
-  "version": "0.1.2-ts.5",
+  "version": "0.1.2-ts.6",
   "description": "",
   "main": "src/lib/init.lua",
   "scripts": {

--- a/src/lib/World.d.ts
+++ b/src/lib/World.d.ts
@@ -58,7 +58,7 @@ export class World {
 	public queryChanged<C extends ComponentCtor, T extends DynamicBundle>(
 		mt: C,
 		...dynamic_bundle: T
-	): IterableFunction<LuaTuple<[Entity<[ReturnType<C>]>, { new: ReturnType<C> | undefined; old: ReturnType<C> }, ...InferComponents<T>]>>;
+	): IterableFunction<LuaTuple<[Entity<[ReturnType<C>]>, { new: ReturnType<C> | undefined; old: ReturnType<C> | undefined }, ...InferComponents<T>]>>;
 
 	public insert(id: AnyEntity, ...dynamic_bundle: ComponentBundle): void;
 


### PR DESCRIPTION
The types right now assume that `old` cannot be `undefined`. However, if a component is brand new and picked up from `queryChanged`, then this is not true.