### PR TITLE
Make defaultData Partial

### DIFF
--- a/lib/component.d.ts
+++ b/lib/component.d.ts
@@ -48,7 +48,7 @@ export type NullableComponents<a extends ComponentBundle> = a extends []
 
 export function newComponent<T extends object>(
 	name?: string,
-	defaultData?: T,
+	defaultData?: Partial<T>,
 ): {
 	(data?: T): Component<T>;
 };


### PR DESCRIPTION
From docs: "If defaultData is specified, it will be merged with data passed to the component when the component instance is created"

I take it this means that defaultData is optional as well as all fields inside of it