### PR TITLE
Fix AnySystem type

### DIFF
--- a/lib/Loop.d.ts
+++ b/lib/Loop.d.ts
@@ -9,7 +9,7 @@ export type SystemStruct<T extends Array<unknown>> = {
 
 export type System<T extends Array<unknown>> = SystemFn<T> | SystemStruct<T>;
 
-export type AnySystem = SystemFn<Array<unknown>> & SystemStruct<Array<unknown>>;
+export type AnySystem = System<unknown[]>;
 /**
  * @class Loop
  *


### PR DESCRIPTION
This fixes the AnySystem type, which was unassignable without an assertion because there is no valid intersection between SystemFn and SystemStruct.