### PR TITLE
fix(view): `get` should be nullable & should not wrap a singular component in a `LuaTuple`

### DIFF
--- a/lib/World.d.ts
+++ b/lib/World.d.ts
@@ -273,7 +273,13 @@ type QueryResult<T extends ComponentBundle> = Query<T> & {
 };
 
 type View<T extends ComponentBundle> = Query<T> & {
-	get: (this: View<T>, id: AnyEntity) => LuaTuple<T>;
+	get<E>(
+		entity: E,
+	): T extends [AnyComponent]
+		? E extends Entity<T>
+			? T[0]
+			: T[0] | undefined
+		: LuaTuple<E extends Entity<T> ? T : NullableArray<T>>;
 	contains: (this: View<T>, id: AnyEntity) => boolean;
 };
 


### PR DESCRIPTION
## Proposed changes

`view:get` should return a nullable array and should not return a `LuaTuple` if there is only one component.

## Related issues

Discussed in [#matter-types](https://discord.com/channels/1234249974959702056/1234254541730353242) at https://discord.com/channels/1234249974959702056/1234254541730353242/1279274683463630908

## Additional comments

N/A. Should be a nice simple PR :)